### PR TITLE
add commas

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,8 @@
   require("fzf").setup{
     mode = "default",
     key = "ctrl-f",
-    bin = "fzf"
-    args = "--preview 'pistol {}'"
+    bin = "fzf",
+    args = "--preview 'pistol {}'",
     recursive = false,  -- If true, search all files under $PWD
     enter_dir = false,  -- Enter if the result is directory
   }


### PR DESCRIPTION
This commit fixes a minor error in the `Installation` step in README.md. Two commas are missing in the `Require Module` step. Without these commas, `xplr` encounters syntax error.